### PR TITLE
Ignore escaped parens for backward compat with 2.x

### DIFF
--- a/lib/cucumber/cucumber_expressions/regular_expression.rb
+++ b/lib/cucumber/cucumber_expressions/regular_expression.rb
@@ -5,7 +5,7 @@ require 'cucumber/cucumber_expressions/tree_regexp'
 module Cucumber
   module CucumberExpressions
     class RegularExpression
-      CAPTURE_GROUP_PATTERN = /\((?!\?:)([^(]+)\)/
+      CAPTURE_GROUP_PATTERN = /(?<!\\)\((?!\?:)([^(]+)\)/
 
       def initialize(expression_regexp, parameter_type_registry)
         @expression_regexp = expression_regexp

--- a/spec/cucumber/cucumber_expressions/regular_expression_spec.rb
+++ b/spec/cucumber/cucumber_expressions/regular_expression_spec.rb
@@ -47,6 +47,10 @@ module Cucumber
         ).to eq(["I", "can", 1, "slide"])
       end
 
+      it "ignores escaped 2.x parenthesis" do
+        expect( match(/Across the line\(s\)/, 'Across the line\(s\)') ).to be_nil
+      end
+
       it "exposes source and regexp" do
         regexp = /I have (\d+) cukes? in my (\+) now/
         expression = RegularExpression.new(regexp, ParameterTypeRegistry.new)


### PR DESCRIPTION
## Bugfix

* When generating step def snippets, Cucumber escapes parens with backslashes and cucumber-expressions-ruby was catching erroneously on that.
* Error: `Expression /^Across the line\(s\)$/ has 0 capture groups ([]), but there were 1 parameter types (["s\\"]) (Cucumber::CucumberExpressions::CucumberExpressionError)`
* [Full stack error here](https://gist.github.com/jaysonesmith/3b17b3dd830cd4b83157a865e82efadf)
* I added a test to the `regular_expression_spec.rb` file and all tests pass successfully. Can someone let me know if my test is configured correctly and in the right place, please?

## Example from my own project
* Step of: `Given I want to request "<caption_count>" caption(s)` in my feature
* Generated snippet from 2.4.0: `Given(/^I want to request "([^"]*)" caption\(s\)$/) do`