### PR TITLE
(Re)allow optional parameter types

### DIFF
--- a/lib/cucumber/cucumber_expressions/parameter_type.rb
+++ b/lib/cucumber/cucumber_expressions/parameter_type.rb
@@ -35,7 +35,8 @@ module Cucumber
       end
 
       def transform(self_obj, group_values)
-        self_obj.instance_exec(*group_values, &@transformer)
+        group_values[0] = nil unless group_values.length > 0
+        self_obj.instance_exec(*group_values, &@transformer)    
       end
 
       def <=>(other)


### PR DESCRIPTION
The difference after the 5.0.16/17 change was that instead of [nil] we now were sending [] when we have an optional param type, which throws an error when you use *. This will just insert a nil if it's empty